### PR TITLE
Feat#22

### DIFF
--- a/src/main/java/com/softgallery/talkativefairytale/auth/JWTFilter.java
+++ b/src/main/java/com/softgallery/talkativefairytale/auth/JWTFilter.java
@@ -1,0 +1,55 @@
+package com.softgallery.talkativefairytale.auth;
+
+import com.softgallery.talkativefairytale.config.SecurityConfig;
+import com.softgallery.talkativefairytale.dto.CustomUserDetails;
+import com.softgallery.talkativefairytale.entity.UserEntity;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+public class JWTFilter extends OncePerRequestFilter {
+    private final JWTUtil jwtUtil;
+
+    public JWTFilter(JWTUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String authorization = request.getHeader("Authorization");
+        if(authorization == null || !authorization.startsWith("Bearer ")) {
+            System.out.println("Token null");
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = authorization.split(" ")[1];
+
+        if(jwtUtil.isExpired(token)) {
+            System.out.println("token is expired");
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String username = jwtUtil.getUsername(token);
+
+        UserEntity userEntity = new UserEntity();
+        userEntity.setUsername(username);
+        userEntity.setPassword("ItIsSecretGiveTempValue");
+
+        CustomUserDetails customUserDetails = new CustomUserDetails(userEntity);
+
+        Authentication authToken = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/softgallery/talkativefairytale/auth/JWTUtil.java
+++ b/src/main/java/com/softgallery/talkativefairytale/auth/JWTUtil.java
@@ -28,7 +28,8 @@ public class JWTUtil {
     public String createJWT(String username, Long expireMs) {
         return Jwts.builder()
                 .claim("username", username)
-                .issuedAt(new Date(System.currentTimeMillis()+expireMs ))
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis()+expireMs))
                 .signWith(secretKey)
                 .compact();
     }

--- a/src/main/java/com/softgallery/talkativefairytale/auth/LoginFilter.java
+++ b/src/main/java/com/softgallery/talkativefairytale/auth/LoginFilter.java
@@ -37,7 +37,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
 
 
-        String token = jwtUtil.createJWT(username, 3600L);
+        String token = jwtUtil.createJWT(username, 31557600000L);
 
         response.addHeader("Authorization", "Bearer " + token);
     }

--- a/src/main/java/com/softgallery/talkativefairytale/auth/LoginFilter.java
+++ b/src/main/java/com/softgallery/talkativefairytale/auth/LoginFilter.java
@@ -37,7 +37,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
 
 
-        String token = jwtUtil.createJWT(username, 31557600000L);
+        String token = jwtUtil.createJWT(username, 3600000L);
 
         response.addHeader("Authorization", "Bearer " + token);
     }

--- a/src/main/java/com/softgallery/talkativefairytale/config/SecurityConfig.java
+++ b/src/main/java/com/softgallery/talkativefairytale/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.softgallery.talkativefairytale.config;
 
+import com.softgallery.talkativefairytale.auth.JWTFilter;
 import com.softgallery.talkativefairytale.auth.JWTUtil;
 import com.softgallery.talkativefairytale.auth.LoginFilter;
 import org.springframework.context.annotation.Bean;
@@ -45,12 +46,14 @@ public class SecurityConfig {
                 .httpBasic((auth) -> auth.disable())
                 .authorizeHttpRequests(request -> request
                         .requestMatchers(
-                                "/version", "/login/google", "/test", "/*", "/api/*", "/register/*", "/character/*"
+                                "/register/*", "/login"
                         )
                         .permitAll()
+                        .anyRequest().authenticated()
                 )
-                .sessionManagement((session) -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(new JWTFilter(jwtUtil), LoginFilter.class)
+                .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil), UsernamePasswordAuthenticationFilter.class)
+                .sessionManagement((session) -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
         return http.build();
     }

--- a/src/main/java/com/softgallery/talkativefairytale/controller/CharacterController.java
+++ b/src/main/java/com/softgallery/talkativefairytale/controller/CharacterController.java
@@ -17,11 +17,6 @@ public class CharacterController {
         this.characterService = characterService;
     }
 
-    @GetMapping("/")
-    public ResponseEntity<String> test() {
-        return ResponseEntity.ok().body("hello");
-    }
-
     @GetMapping("/setCharacterTable")
     public ResponseEntity<String> setCharacterTable() {
         characterService.setCharacterTable();

--- a/src/main/java/com/softgallery/talkativefairytale/controller/HomepageController.java
+++ b/src/main/java/com/softgallery/talkativefairytale/controller/HomepageController.java
@@ -15,8 +15,8 @@ public class HomepageController {
     }
 
     @GetMapping("/test")
-    public String test() {
-        return "test";
+    public ResponseEntity<String> test() {
+        return ResponseEntity.ok().body("auth OK");
     }
 
     @PostMapping("/login")

--- a/src/main/java/com/softgallery/talkativefairytale/dto/UserDTO.java
+++ b/src/main/java/com/softgallery/talkativefairytale/dto/UserDTO.java
@@ -8,6 +8,8 @@ public class UserDTO {
 
     private String password;
 
+    public UserDTO() {};
+
     public UserDTO(String username, String password) {
         this.username = username;
         this.password = password;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,5 +8,5 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 jwt.secret=awejlkfjeawljfawekflsdjlkawjsefiaflksdjflkasjfalkjlskfjdlksjfiaw
 jwt.token-validity-in-seconds=3600
 
-spring.jpa.hibernate.ddl-auto=create
+spring.jpa.hibernate.ddl-auto=none
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,5 +8,5 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 jwt.secret=awejlkfjeawljfawekflsdjlkawjsefiaflksdjflkasjfalkjlskfjdlksjfiaw
 jwt.token-validity-in-seconds=3600
 
-spring.jpa.hibernate.ddl-auto=none
+spring.jpa.hibernate.ddl-auto=create
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl


### PR DESCRIPTION
## PR Type(Choose one)
- [X] 기능 추가
- [ ] 기능 삭제
- [X] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## Changed Branch
ex) feat#22 -> dev

## Changes
JWT 토큰이 있는 사용자는 API콜을 할 수 있게 했고, JWT 토큰이 없는 사용자는 로그인, 회원가입을 제외한 API를 콜할 수 없게 했습니다.(콜하면 403에러 발생)

## Screenshot
코드 사진 첨부

## Note
이제부터 API를 만든 후 테스트 하려고 해도 토큰이 없어서 에러가 날 텐데 2가지 방법이 있습니다.
1. config 폴던 안에 `public SecurityFilterChain filterChain(HttpSecurity http) throws Exception()` 라는 메서드가 있는데, 이 안에 보면 
```
                .authorizeHttpRequests(request -> request
                        .requestMatchers(
                                "/register/*", "/login"
                        )
                        .permitAll()
                        .anyRequest().authenticated()
                )
```
가 있다. 여기서 `.requestMatchers()안에 내가 새로 만든 API 경로를 넣으면, 그 API는 토큰과 상관 없이 콜할 수 있다.(이미 있는 `/register/*`, `/login` 참조)

2. 로그인 후 JWT 토큰을 얻어, 이후 API를 콜할 때 헤더에 토큰 값을 넣어주기
조금 복잡하고 번거로울까봐 미리 1년짜리 슈퍼 토큰을 만들어 두었습니다. 노션에 보면 있어요. 이걸 post맨에서 보낼때 헤더에 넣어서 보내면 됌. 노션에 사진도 첨부해 둠.

둘 중 아무 방법이나 하면 테스트 가능합니다.
