### PR TITLE
[Feat#44] 이야기 저장 기능 구현

### DIFF
--- a/src/main/java/com/softgallery/talkativefairytale/controller/CharacterController.java
+++ b/src/main/java/com/softgallery/talkativefairytale/controller/CharacterController.java
@@ -48,15 +48,15 @@ public class CharacterController {
         return ResponseEntity.ok().body(testOutput);
     }
 
-    @PostMapping("/insert")
-    public ResponseEntity<CharacterDTO> insertCharacterTest(@RequestBody CharacterDTO characterDTO) {
-        CharacterDTO newCharacter = storyMakingService.insertNewCharacter(characterDTO);
-        return ResponseEntity.created(URI.create("/character/insert/" + newCharacter.getCharacterId())).body(newCharacter);
-    }
-
-    @GetMapping("/find/id/{id}")
-    public ResponseEntity<CharacterDTO> readCharacterIdTest(@PathVariable Long id) {
-        CharacterDTO foundCharacter = storyMakingService.findCharacterById(id);
-        return ResponseEntity.ok().body(foundCharacter);
-    }
+//    @PostMapping("/insert")
+//    public ResponseEntity<CharacterDTO> insertCharacterTest(@RequestBody CharacterDTO characterDTO) {
+//        CharacterDTO newCharacter = storyMakingService.insertNewCharacter(characterDTO);
+//        return ResponseEntity.created(URI.create("/character/insert/" + newCharacter.getCharacterId())).body(newCharacter);
+//    }
+//
+//    @GetMapping("/find/id/{id}")
+//    public ResponseEntity<CharacterDTO> readCharacterIdTest(@PathVariable Long id) {
+//        CharacterDTO foundCharacter = storyMakingService.findCharacterById(id);
+//        return ResponseEntity.ok().body(foundCharacter);
+//    }
 }

--- a/src/main/java/com/softgallery/talkativefairytale/controller/MainpageController.java
+++ b/src/main/java/com/softgallery/talkativefairytale/controller/MainpageController.java
@@ -1,45 +1,38 @@
 package com.softgallery.talkativefairytale.controller;
 
 import com.softgallery.talkativefairytale.dto.StoryDTO;
-import com.softgallery.talkativefairytale.dto.UserDTO;
 import com.softgallery.talkativefairytale.service.story.MainpageService;
-import com.softgallery.talkativefairytale.service.story.StoryMaking;
+import com.softgallery.talkativefairytale.service.story.StoryMakingService;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
 @RequestMapping("/main")
 public class MainpageController {
     private final MainpageService mainpageService;
-    private final StoryMaking storyMaking;
 
-    private ArrayList<StoryDTO> completeStories = new ArrayList<>();
-    private ArrayList<StoryDTO> incompleteStories = new ArrayList<>();
-
-    public MainpageController(MainpageService mainpageService, StoryMaking storyMaking) {
+    public MainpageController(final MainpageService mainpageService) {
         this.mainpageService = mainpageService;
-        this.storyMaking = storyMaking;
     }
 
-    @PostMapping("/")
-    public ResponseEntity<Map<String, Object>> main(@RequestBody UserDTO userDTO) {
-        Map<String, Object> responseEntity = new HashMap<>();
+    @PostMapping("/list/incomplete")
+    public ResponseEntity<List<StoryDTO>> loadIncompleteStories(@RequestHeader(name = "Authorization") String userToken) {
+        List<StoryDTO> incompleteStories = mainpageService.findIncompleteStoriesMadeByUserName(userToken);
 
-//        // 여기서 페이지 로딩에 필요한 데이터들 다 불러오기
-//        incompleteStories = mainpageService.findIncompleteStoriesMadeByUserName(userDTO.getUsername());
-//        completeStories = mainpageService.findCompleteStoriesMadeByUserName(userDTO.getUsername());
-//
-//        // 한번에 Map으로 집어넣어서 보내기
-//        responseEntity.put("incompleteStories", incompleteStories);
-//        responseEntity.put("completeStories", completeStories);
-
-        return ResponseEntity.ok().body(responseEntity);
+        return ResponseEntity.ok().body(incompleteStories);
     }
 
+    @PostMapping("/list/complete")
+    public ResponseEntity<List<StoryDTO>> loadCompleteStories(@RequestHeader(name = "Authorization") String userToken) {
+        List<StoryDTO> completeStories = mainpageService.findCompleteStoriesMadeByUserName(userToken);
+
+        return ResponseEntity.ok().body(completeStories);
+    }
 }

--- a/src/main/java/com/softgallery/talkativefairytale/controller/MainpageController.java
+++ b/src/main/java/com/softgallery/talkativefairytale/controller/MainpageController.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,14 +23,14 @@ public class MainpageController {
         this.mainpageService = mainpageService;
     }
 
-    @PostMapping("/list/incomplete")
+    @GetMapping("/list/incomplete")
     public ResponseEntity<List<StoryDTO>> loadIncompleteStories(@RequestHeader(name = "Authorization") String userToken) {
         List<StoryDTO> incompleteStories = mainpageService.findIncompleteStoriesMadeByUserName(userToken);
 
         return ResponseEntity.ok().body(incompleteStories);
     }
 
-    @PostMapping("/list/complete")
+    @GetMapping("/list/complete")
     public ResponseEntity<List<StoryDTO>> loadCompleteStories(@RequestHeader(name = "Authorization") String userToken) {
         List<StoryDTO> completeStories = mainpageService.findCompleteStoriesMadeByUserName(userToken);
 

--- a/src/main/java/com/softgallery/talkativefairytale/controller/StoryMakingPageController.java
+++ b/src/main/java/com/softgallery/talkativefairytale/controller/StoryMakingPageController.java
@@ -1,55 +1,48 @@
 package com.softgallery.talkativefairytale.controller;
 
-import static java.lang.Long.parseLong;
-
 import com.softgallery.talkativefairytale.dto.StoryDTO;
-import com.softgallery.talkativefairytale.dto.UserDTO;
-import com.softgallery.talkativefairytale.service.story.StoryMaking;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
+import com.softgallery.talkativefairytale.service.story.StoryMakingService;
+import java.util.Map;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 @RequestMapping("/make")
 public class StoryMakingPageController {
-    private StoryMaking storyMaking;
-    private StoryDTO currentStory, prevStory;
+    private final StoryMakingService storyMakingService;
 
-    public StoryMakingPageController(final StoryMaking storyMaking) {
-        this.storyMaking = storyMaking;
+    public StoryMakingPageController(final StoryMakingService storyMakingService) {
+        this.storyMakingService = storyMakingService;
     }
 
     @PostMapping("/")
-    public ResponseEntity<StoryDTO> makeStory(@RequestBody UserDTO userDTO, @RequestParam(value = "topic") String topic,
-                            @RequestParam(value = "level", defaultValue = "1") String level) {
-        System.out.println("topic: " + topic + "level: " + level);
-        currentStory = new StoryDTO("No Title", userDTO.getUsername(), "", topic, parseLong(level), false, LocalDateTime.now());
-        currentStory = storyMaking.createStory(currentStory);
+    public ResponseEntity<StoryDTO> makeStory(@RequestHeader(name = "Authorization") String userToken) {
+        StoryDTO currentStory = storyMakingService.createStory(userToken);
         return ResponseEntity.ok().body(currentStory);
     }
 
-//    @PostMapping("/new/content")
-//    public ResponseEntity<StoryDTO> addContent(@RequestBody StoryDTO storyInfo) {
-//        StoryDTO updatedStory = storyMaking.addContentToStory(storyInfo.getId(), storyInfo.getContent());
-//        return ResponseEntity.ok().body(updatedStory);
-//    }
+    @PostMapping("/{storyId}")
+    public ResponseEntity<StoryDTO> loadStory(@RequestHeader(name = "Authorization") String userToken,
+                                              @PathVariable Long storyId) {
+        StoryDTO loadedStory = storyMakingService.findStoryByStoryId(storyId);
+        return ResponseEntity.ok().body(loadedStory);
+    }
 
-//    @PostMapping("/resume")   // <username, id>
-//    public ResponseEntity<StoryDTO> resumeStory(@RequestBody Map<String, String> storyInfo) {
-//        prevStory = storyMaking.findStoryByUsernameAndId(storyInfo);
-//        currentStory = storyMaking.resumeMakingStory(prevStory, "");
-//        return ResponseEntity.ok().body(currentStory);
-//    }
-//
-//    @PostMapping("/save")
-//    public String saveStory(@Request) {
-//
-//    }
+    @PostMapping("/{storyId}/append")
+    public ResponseEntity<StoryDTO> appendContent(@RequestHeader(name = "Authorization") String userToken,
+                                                  @PathVariable Long storyId,
+                                                  @RequestBody Map<String, String> newStory) {
+        StoryDTO updatedStory = storyMakingService.addContentToStory(userToken, storyId, newStory);
+        return ResponseEntity.ok().body(updatedStory);
+    }
 
-//    @PostMapping("/save/complete")
+    @PostMapping("/{storyId}/resume")
+    public boolean resumeStory(@PathVariable Long storyId) {
+        return storyMakingService.changeStoryStateIncomplete(storyId);
+    }
 }

--- a/src/main/java/com/softgallery/talkativefairytale/controller/StoryMakingPageController.java
+++ b/src/main/java/com/softgallery/talkativefairytale/controller/StoryMakingPageController.java
@@ -5,6 +5,7 @@ import com.softgallery.talkativefairytale.service.story.StoryMakingService;
 import java.util.Map;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -26,7 +27,7 @@ public class StoryMakingPageController {
         return ResponseEntity.ok().body(currentStory);
     }
 
-    @PostMapping("/{storyId}")
+    @GetMapping("/{storyId}")
     public ResponseEntity<StoryDTO> loadStory(@RequestHeader(name = "Authorization") String userToken,
                                               @PathVariable Long storyId) {
         StoryDTO loadedStory = storyMakingService.findStoryByStoryId(storyId);

--- a/src/main/java/com/softgallery/talkativefairytale/data/GPTPromptingInfo.java
+++ b/src/main/java/com/softgallery/talkativefairytale/data/GPTPromptingInfo.java
@@ -34,9 +34,8 @@ public class GPTPromptingInfo {
         return this.adaptingKoreanStyleMessage;
     }
 
-    public String getStoryContinuingMessage(String topic, Long level, String prevStory) {
+    public String getStoryContinuingMessage(String prevStory) {
         String result = this.storyContinuingMessage + "\n\n"
-                + "이야기의 주제는 " + topic + " 이고, "
                 + "지금까지 만들어진 이야기는 다음과 같아\n\n"
                 + prevStory;
         return result;

--- a/src/main/java/com/softgallery/talkativefairytale/dto/CharacterDTO.java
+++ b/src/main/java/com/softgallery/talkativefairytale/dto/CharacterDTO.java
@@ -1,6 +1,5 @@
 package com.softgallery.talkativefairytale.dto;
 
-import com.softgallery.talkativefairytale.domain.Character;
 import com.softgallery.talkativefairytale.entity.CharacterEntity;
 
 public class CharacterDTO {
@@ -43,16 +42,6 @@ public class CharacterDTO {
         this.personalityBad = personalityBad;
         this.personalityNormal = personalityNormal;
         this.whoMade = whoMade;
-    }
-
-    public CharacterDTO(Character character) {
-        this.characterId = character.getId();
-        this.name = character.getName();
-        this.gender = character.getGender();
-        this.personalityGood = character.getPersonalityGood();
-        this.personalityBad = character.getPersonalityBad();
-        this.personalityNormal = character.getPersonalityNormal();
-        this.whoMade = character.getWhoMade();
     }
 
     public Long getCharacterId() {

--- a/src/main/java/com/softgallery/talkativefairytale/dto/StoryDTO.java
+++ b/src/main/java/com/softgallery/talkativefairytale/dto/StoryDTO.java
@@ -62,11 +62,10 @@ public class StoryDTO {
         this.level = storyEntity.getLevel();
         this.isCompleted = storyEntity.getIsCompleted();
         this.modifiedDate = storyEntity.getModifiedDate();
+        this.visibility = storyEntity.getVisibility();
+        this.likeNum = storyEntity.getLikeNum();
+        this.dislikeNum = storyEntity.getDislikeNum();
     }
 
     public void setContent(String content) { this.content = content; }
-
-    public Boolean getCompleted() {
-        return isCompleted;
-    }
 }

--- a/src/main/java/com/softgallery/talkativefairytale/entity/StoryEntity.java
+++ b/src/main/java/com/softgallery/talkativefairytale/entity/StoryEntity.java
@@ -1,6 +1,7 @@
 package com.softgallery.talkativefairytale.entity;
 
 import com.softgallery.talkativefairytale.service.story.Visibility;
+import jakarta.annotation.Nullable;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import javax.validation.constraints.NotNull;
@@ -28,7 +29,7 @@ public class StoryEntity {
     private String username;
 
     @Column
-    @NotNull
+    @Nullable
     private String topic;
 
     @Column

--- a/src/main/java/com/softgallery/talkativefairytale/service/story/StoryMakingService.java
+++ b/src/main/java/com/softgallery/talkativefairytale/service/story/StoryMakingService.java
@@ -1,5 +1,6 @@
 package com.softgallery.talkativefairytale.service.story;
 
+import com.softgallery.talkativefairytale.auth.JWTUtil;
 import com.softgallery.talkativefairytale.data.GPTPromptingInfo;
 import com.softgallery.talkativefairytale.dto.*;
 
@@ -10,8 +11,11 @@ import com.softgallery.talkativefairytale.repository.StoryRepository;
 import com.softgallery.talkativefairytale.service.character.CharacterService;
 import com.softgallery.talkativefairytale.service.chatGpt.ChatGptService;
 import com.softgallery.talkativefairytale.service.chatGpt.Choice;
+import com.softgallery.talkativefairytale.service.chatGpt.Message;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.springframework.stereotype.Service;
 
@@ -22,166 +26,175 @@ public class StoryMakingService {
     private final StoryRepository storyRepository;
     private final CharacterRepository characterRepository;
     private final GPTPromptingInfo gptPromptingInfo = new GPTPromptingInfo();
+    private final JWTUtil jwtUtil;
 
-    private StoryEntity currentStory;
     private ArrayList<CharacterDTO> characters;
 
     public StoryMakingService (final CharacterService characterService, final ChatGptService chatGptService,
-                       final StoryRepository storyRepository, final CharacterRepository characterRepository) {
+                               final StoryRepository storyRepository, final CharacterRepository characterRepository,
+                               final JWTUtil jwtUtil) {
         this.characterService = characterService;
         this.chatGptService = chatGptService;
         this.storyRepository = storyRepository;
         this.characterRepository = characterRepository;
+        this.jwtUtil = jwtUtil;
     }
 
     private void updateCharacterList(CharacterEntity character) {
         characters.add(new CharacterDTO(character));
     }
 
-    public StoryDTO createStory(StoryDTO emptyStoryDTO) {
-        characters = new ArrayList<>(List.of(characterService.selectCharacters()));
+    public StoryDTO createStory(String userToken) {
+//        characters = new ArrayList<>(List.of(characterService.selectCharacters()));
+        String username = jwtUtil.getUsername(JWTUtil.getOnlyToken(userToken));
 
-        String question = createGPTQuery(emptyStoryDTO.getTopic(),
-                emptyStoryDTO.getLevel(), "", characters);
+        // 시스템 프롬프트 적용
+        Message message = new Message("system", createGPTQuery(""));
+        List<Message> messages = new ArrayList<>();
+        messages.add(message);
 
-        ChatGptResponseDTO responseDTO = chatGptService.askQuestion(new QuestionRequestDTO());
+        // 프롬프트 적용 후 쿼리 날려서 받아오기
+        ChatGptResponseDTO responseDTO = chatGptService.askQuestion(new QuestionRequestDTO(messages));
         Choice choice = responseDTO.getChoices().get(0);
 
-        currentStory = new StoryEntity();
-        currentStory.setTitle(emptyStoryDTO.getTitle());
-        currentStory.setUsername(emptyStoryDTO.getUsername());
-        currentStory.setTopic(emptyStoryDTO.getTopic());
-        currentStory.setLevel(currentStory.getLevel());
-        currentStory.setIsCompleted(emptyStoryDTO.getCompleted());
-        currentStory.setContent(question + "\n" + "<gpt>\n" + choice.getMessage());
-        currentStory.setModifiedDate(emptyStoryDTO.getModifiedDate());
-
-//        currentStory = new StoryEntity(
-//                emptyStoryDTO.getTitle(),
-//                emptyStoryDTO.getUsername(),
-//                emptyStoryDTO.getTopic(),
-//                emptyStoryDTO.getLevel(),
-//                emptyStoryDTO.getCompleted(),
-//                question + "\n" + "<gpt>\n" + choice.getMessage(),
-//                emptyStoryDTO.getModifiedDate());
+        StoryEntity currentStory = new StoryEntity();
+        currentStory.setTitle("No Title");
+        currentStory.setUsername(username);
+        currentStory.setTopic("Default Topic");
+        currentStory.setLevel(1L);
+        currentStory.setIsCompleted(false);
+        currentStory.setContent("<gpt>\n" + choice.getMessage().getContent());
+        currentStory.setModifiedDate(LocalDateTime.now());
+        currentStory.setLikeNum(0L);
+        currentStory.setDislikeNum(0L);
+        currentStory.setVisibility(Visibility.PRIVATE);
 
         StoryEntity savedStory = storyRepository.save(currentStory);
 
         return new StoryDTO(savedStory);
     }
 
-    public StoryDTO addContentToStory(Long idStory, String newContent) {
-        Optional<StoryEntity> storyEntityOptional = storyRepository.findById(idStory);
+    public StoryDTO addContentToStory(String userToken, Long storyId, Map<String, String> userInput) {
+        Optional<StoryEntity> storyEntityOptional = storyRepository.findById(storyId);
         if(storyEntityOptional.isEmpty()) throw new RuntimeException("No such story");
 
         StoryEntity previousStoryEntity = storyEntityOptional.get();
         StoryDTO previousStoryDTO = new StoryDTO(previousStoryEntity);
 
-        String updatedContent = previousStoryDTO.getContent() + "<user>\n" + newContent;
+        String authorName = jwtUtil.getUsername(JWTUtil.getOnlyToken(userToken));
+        if(!authorName.equals(previousStoryDTO.getUsername())) throw new RuntimeException("No Permission to Modify");
 
-        String question = createGPTQuery(previousStoryDTO.getTopic(),
-                previousStoryDTO.getLevel(), updatedContent, characters);
+        if(previousStoryEntity.getIsCompleted()) throw new RuntimeException("Already completed story");
 
-        ChatGptResponseDTO responseDTO = chatGptService.askQuestion(new QuestionRequestDTO(question));
+        // 예외처리 통과 후
+        String updatedContent = previousStoryDTO.getContent() + "\n<user>\n" + userInput.get("newStory");
+
+        Message message = new Message("system", createGPTQuery(updatedContent));
+        List<Message> messages = new ArrayList<>();
+        messages.add(message);
+
+        // 유저가 보낸 내용에 따라 GPT가 응답 생성
+        ChatGptResponseDTO responseDTO = chatGptService.askQuestion(new QuestionRequestDTO(messages));
         Choice choice = responseDTO.getChoices().get(0);
 
-        String addedSentence = updatedContent + "\n<gpt>\n" + choice.getMessage();
+        String addedSentence = updatedContent + "\n<gpt>\n" + choice.getMessage().getContent();
 
-//        previousStoryDTO.setContent(addedSentence);
-//        storyDAO.updateStoryContent(previousStoryDTO.getId(), addedSentence);
-
+        // GPT 응답을 포함하여 DB 저장 및 반환
+        previousStoryDTO.setContent(addedSentence);
         previousStoryEntity.setContent(addedSentence);
         storyRepository.save(previousStoryEntity);
 
         return previousStoryDTO;
     }
 
-//    public StoryDTO resumeMakingStory(StoryDTO previousStoryDTO) {
-//        characters = new ArrayList<>(List.of(characterService.selectCharacters()));
-//
-//        currentStory = new StoryDTO(
-//                previousStoryDTO.getTitle(),
-//                previousStoryDTO.getUsername(),
-//                newContent + "\n" + choice.getText(),
-//                previousStoryDTO.getTopic(),
-//                previousStoryDTO.getLevel(),
-//                previousStoryDTO.getCompleted(),
-//                previousStoryDTO.getModifiedDate());
-//
-//        return currentStory;
-//    }
+    public boolean changeStoryStateIncomplete(Long storyId) {
+        Optional<StoryEntity> storyEntityOptional = storyRepository.findById(storyId);
+        if(storyEntityOptional.isEmpty()) throw new RuntimeException("No such story");
 
-    public String createGPTQuery(String topic, Long level, String prevStory, ArrayList<CharacterDTO> characters) {
+        StoryEntity story = storyEntityOptional.get();
+        story.setIsCompleted(false);
+        return true;
+    }
+
+    public String createGPTQuery(String prevStory) {
         if(prevStory.isEmpty()) {   // 이전 이야기가 없는 경우 (작성 시작 시)
-            CharacterDTO mainCharacter = characters.get(0);
-            CharacterDTO villain = characters.get(1);
+//            CharacterDTO mainCharacter = characters.get(0);
+//            CharacterDTO villain = characters.get(1);
 
             String result = gptPromptingInfo.getInitalizingMessage() + "\n"
                     + gptPromptingInfo.getStyleOptimizingMessage() + "\n\n"
                     + "너는 위 정보를 가지고 이야기의 도입부분을 한국어로 만들어줘야해.\n"
-                    + "등장인물의 정보는 아래와 같아.\n\n"
-                    + "<주인공>\n" + mainCharacter.getName() + " : " + mainCharacter.getPersonalityGood() + "\n"
-                    + "<악당>\n" + villain.getName() + " : " + villain.getPersonalityBad() + "\n";
+                    ;
+//                    + "등장인물의 정보는 아래와 같아.\n\n"
+//                    + "<주인공>\n" + mainCharacter.getName() + " : " + mainCharacter.getPersonalityGood() + "\n"
+//                    + "<악당>\n" + villain.getName() + " : " + villain.getPersonalityBad() + "\n";
 
-            for(int i = 2; i < characters.size(); i++) {
-                CharacterDTO character = characters.get(i);
-
-                if(i == 2) {
-                    result += "<조연>\n" + character.getName() + " : " + character.getPersonalityNormal() + "\n";
-                }
-                else {
-                    result += character.getName() + " : " + character.getPersonalityNormal() + "\n";
-                }
-            }
+//            for(int i = 2; i < characters.size(); i++) {
+//                CharacterDTO character = characters.get(i);
+//
+//                if(i == 2) {
+//                    result += "<조연>\n" + character.getName() + " : " + character.getPersonalityNormal() + "\n";
+//                }
+//                else {
+//                    result += character.getName() + " : " + character.getPersonalityNormal() + "\n";
+//                }
+//            }
 
             return result;
         }
         else {  // 이야기에 문장 추가
-            String result = gptPromptingInfo.getStoryContinuingMessage(topic, level, prevStory);
+            String result = gptPromptingInfo.getStoryContinuingMessage(prevStory);
             return result;
         }
+    }
+
+    public StoryDTO findStoryByStoryId(Long storyId) {
+        Optional<StoryEntity> storyEntityOptional = storyRepository.findById(storyId);
+        if(storyEntityOptional.isEmpty()) throw new RuntimeException("No such story");
+
+        return new StoryDTO(storyEntityOptional.get());
     }
 
 //    public StoryDTO findStoryByUsernameAndId(Map<String, String> storyInfo) {
 //        Story story = storyDAO.findIncompleteStoriesByName(storyInfo.);
 //    }
 
-    public CharacterDTO findCharacterById(Long characterId) {
-//        Character character = characterDAO.findCharacterById(characterId);
+//    public CharacterDTO findCharacterById(Long characterId) {
+////        Character character = characterDAO.findCharacterById(characterId);
+////        System.out.println("Found character : " + character.getName());
+////        updateCharacterList(character);
+////        return new CharacterDTO(character);
+//
+//        Optional<CharacterEntity> characterOptional = characterRepository.findByCharacterId(characterId);
+//        CharacterEntity character = characterOptional.get();
 //        System.out.println("Found character : " + character.getName());
 //        updateCharacterList(character);
 //        return new CharacterDTO(character);
+//    }
 
-        Optional<CharacterEntity> characterOptional = characterRepository.findByCharacterId(characterId);
-        CharacterEntity character = characterOptional.get();
-        System.out.println("Found character : " + character.getName());
-        updateCharacterList(character);
-        return new CharacterDTO(character);
-    }
-
-    public CharacterDTO findCharacterByName(String characterName) {
-//        Character character = characterDAO.findCharacterByName(characterName);
+//    public CharacterDTO findCharacterByName(String characterName) {
+////        Character character = characterDAO.findCharacterByName(characterName);
+////        System.out.println("Found character : " + character.getName());
+////        updateCharacterList(character);
+////        return new CharacterDTO(character);
+//
+//        Optional<CharacterEntity> characterOptional = characterRepository.findByName(characterName);
+//        CharacterEntity character = characterOptional.get();
 //        System.out.println("Found character : " + character.getName());
 //        updateCharacterList(character);
 //        return new CharacterDTO(character);
-
-        Optional<CharacterEntity> characterOptional = characterRepository.findByName(characterName);
-        CharacterEntity character = characterOptional.get();
-        System.out.println("Found character : " + character.getName());
-        updateCharacterList(character);
-        return new CharacterDTO(character);
-    }
-
-    public CharacterDTO insertNewCharacter(CharacterDTO characterDTO) {
-        CharacterEntity character = new CharacterEntity();
-        character.setName(characterDTO.getName());
-        character.setGender(characterDTO.getGender());
-        character.setPersonalityGood(characterDTO.getPersonalityGood());
-        character.setPersonalityBad(characterDTO.getPersonalityBad());
-        character.setPersonalityNormal(characterDTO.getPersonalityNormal());
-        character.setWhoMade(character.getWhoMade());
-
-        CharacterEntity savedCharacter = characterRepository.save(character);
-        return new CharacterDTO(savedCharacter);
-    }
+//    }
+//
+//    public CharacterDTO insertNewCharacter(CharacterDTO characterDTO) {
+//        CharacterEntity character = new CharacterEntity();
+//        character.setName(characterDTO.getName());
+//        character.setGender(characterDTO.getGender());
+//        character.setPersonalityGood(characterDTO.getPersonalityGood());
+//        character.setPersonalityBad(characterDTO.getPersonalityBad());
+//        character.setPersonalityNormal(characterDTO.getPersonalityNormal());
+//        character.setWhoMade(character.getWhoMade());
+//
+//        CharacterEntity savedCharacter = characterRepository.save(character);
+//        return new CharacterDTO(savedCharacter);
+//    }
 }


### PR DESCRIPTION
## PR Type(Choose one)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## Changed Branch
- feat/#44 -> dev

## Changes
- 이야기 저장 기능 구현 완료
- 이야기 최초 생성 및 추가 문장 저장 로직 분리
- Mainpage 로딩 시 사용자가 작성한 이야기 리스트 로드 기능 추가

## Screenshot
생략

## Note
- 이야기를 최초 생성할 때와 새로운 문장만 추가할 때 불러야 하는 엔드포인트가 다릅니다. (/make    /make/{storyId}/append)
- Mainpage에서 리스트 불러올 때는 완성된 이야기를 부르는 엔드포인트(main/list/complete)와 미완성된 이야기를 부르는 엔드포인트(main/list/incomplete)를 둘 다 불러줘야 합니다. 